### PR TITLE
Bugfix/multi submit uses local

### DIFF
--- a/spark-launch/src/main/scala/com/ibm/sparktc/sparkbench/sparklaunch/SparkLaunchConf.scala
+++ b/spark-launch/src/main/scala/com/ibm/sparktc/sparkbench/sparklaunch/SparkLaunchConf.scala
@@ -49,9 +49,9 @@ object SparkLaunchConf {
       else sparkConfMaps
     }
 
-    assert(sparkConfMaps.contains("master"))
+    assert(correctedSparkConf.contains("master"))
 
-    sparkConfMaps.foldLeft(Array[String]()) { case (arr, (k, v)) => arr ++ Array(s"--$k $v") }
+    correctedSparkConf.foldLeft(Array[String]()) { case (arr, (k, v)) => arr ++ Array(s"--$k $v") }
   }
 
   def getSparkBenchJar(sparkContextConf: Config): String = {

--- a/spark-launch/src/main/scala/com/ibm/sparktc/sparkbench/sparklaunch/SparkLaunchConf.scala
+++ b/spark-launch/src/main/scala/com/ibm/sparktc/sparkbench/sparklaunch/SparkLaunchConf.scala
@@ -41,9 +41,12 @@ object SparkLaunchConf {
   def getSparkArgs(sparkContextConf: Config): Array[String] = {
     val sparkConfMaps = Try(sparkContextConf.getObject("spark-args")).map(toStringMap).getOrElse(Map.empty)
 
-    if(!sparkConfMaps.contains("master")) {
-      val envMaster = getOrThrow(sys.env.get("SPARK_MASTER_HOST"))
-      sparkConfMaps ++ Map("master" -> envMaster)
+    val correctedSparkConf = {
+      if(!sparkConfMaps.contains("master")) {
+        val envMaster = getOrThrow(sys.env.get("SPARK_MASTER_HOST"))
+        sparkConfMaps ++ Map("master" -> envMaster)
+      }
+      else sparkConfMaps
     }
 
     assert(sparkConfMaps.contains("master"))

--- a/spark-launch/src/main/scala/com/ibm/sparktc/sparkbench/sparklaunch/SparkLaunchConf.scala
+++ b/spark-launch/src/main/scala/com/ibm/sparktc/sparkbench/sparklaunch/SparkLaunchConf.scala
@@ -3,6 +3,7 @@ package com.ibm.sparktc.sparkbench.sparklaunch
 import java.io.File
 
 import com.ibm.sparktc.sparkbench.utils.SparkBenchException
+import com.ibm.sparktc.sparkbench.utils.GeneralFunctions._
 import com.typesafe.config.{Config, ConfigObject}
 
 import scala.collection.JavaConverters._
@@ -39,6 +40,14 @@ object SparkLaunchConf {
 
   def getSparkArgs(sparkContextConf: Config): Array[String] = {
     val sparkConfMaps = Try(sparkContextConf.getObject("spark-args")).map(toStringMap).getOrElse(Map.empty)
+
+    if(!sparkConfMaps.contains("master")) {
+      val envMaster = getOrThrow(sys.env.get("SPARK_MASTER_HOST"))
+      sparkConfMaps ++ Map("master" -> envMaster)
+    }
+
+    assert(sparkConfMaps.contains("master"))
+
     sparkConfMaps.foldLeft(Array[String]()) { case (arr, (k, v)) => arr ++ Array(s"--$k $v") }
   }
 


### PR DESCRIPTION
Bug fix for when spark-bench was defaulting to local when master was not specified in the config. Now it prefers master in the config file, will fall back to environment variable, and if there's no environment variable will throw exception.