### PR TITLE
Clean up test files

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -202,6 +202,13 @@ rmDist := {
   log.info("Distribution files removed.")
 }
 
+val rmTemp = TaskKey[Unit]("rmTemp", "removes temporary testing files")
+rmTemp := {
+  val tmpFolder = "/tmp/spark-bench-scalatest"
+  streams.value.log.info(s"Removing $tmpFolder...")
+  s"rm -rf $tmpFolder".!
+}
+
 dist := (dist dependsOn assembly).value
 
-clean := (clean dependsOn rmDist).value
+clean := (clean dependsOn rmDist dependsOn rmTemp).value

--- a/cli/src/test/resources/etc/notebook-sim.conf
+++ b/cli/src/test/resources/etc/notebook-sim.conf
@@ -16,7 +16,7 @@ spark-bench = {
         workloads = [
           {
             name = ["sql"]
-            input = ["notebook-sim-test/spark-bench-test/giant-kmeans-data.parquet"]
+            input = ["/tmp/spark-bench-scalatest/notebook-sim-test/spark-bench-test/giant-kmeans-data.parquet"]
             query = ["select `0` from input where `0` < -0.9"]
           },
           {
@@ -26,7 +26,7 @@ spark-bench = {
           {
             name = ["kmeans"]
             k = [40]
-            input = ["notebook-sim-test/spark-bench-test/giant-kmeans-data.parquet"]
+            input = ["/tmp/spark-bench-scalatest/notebook-sim-test/spark-bench-test/giant-kmeans-data.parquet"]
           },
           {
             name = ["sleep"]
@@ -44,7 +44,7 @@ spark-bench = {
         workloads = [
           {
             name = ["sql"]
-            input = ["notebook-sim-test/spark-bench-test/tiny-kmeans-data.parquet"]
+            input = ["/tmp/spark-bench-scalatest/notebook-sim-test/spark-bench-test/tiny-kmeans-data.parquet"]
             query = ["select `0` from input where `0` < -0.9"]
           },
           {
@@ -53,7 +53,7 @@ spark-bench = {
           },
           {
             name = ["sql"]
-            input = ["notebook-sim-test/spark-bench-test/tiny-kmeans-data.parquet"]
+            input = ["/tmp/spark-bench-scalatest/notebook-sim-test/spark-bench-test/tiny-kmeans-data.parquet"]
             query = ["select `0` from input where `0` < -0.8"]
           },
           {
@@ -62,7 +62,7 @@ spark-bench = {
           },
           {
             name = ["sql"]
-            input = ["notebook-sim-test/spark-bench-test/tiny-kmeans-data.parquet"]
+            input = ["/tmp/spark-bench-scalatest/notebook-sim-test/spark-bench-test/tiny-kmeans-data.parquet"]
             query = ["select `0` from input where `0` < -0.7"]
           },
           {

--- a/cli/src/test/resources/etc/testConfFile1.conf
+++ b/cli/src/test/resources/etc/testConfFile1.conf
@@ -9,17 +9,17 @@ spark-bench = {
         descr = "KMeans in parallel with k = 1, 2"
         parallel = true
         repeat = 5
-        benchmark-output = "tmp/spark-bench-test/conf-file-output-1.csv"
+        benchmark-output = "/tmp/spark-bench-scalatest/tmp/spark-bench-test/conf-file-output-1.csv"
 
         workloads = [
           {
             name = ["kmeans"]
-            input = ["tmp/spark-bench-test/kmeans-data.parquet"]
+            input = ["/tmp/spark-bench-scalatest/tmp/spark-bench-test/kmeans-data.parquet"]
             k = [1]
           },
           {
             name = ["kmeans"]
-            input = ["tmp/spark-bench-test/kmeans-data.parquet"]
+            input = ["/tmp/spark-bench-scalatest/tmp/spark-bench-test/kmeans-data.parquet"]
             k = [2]
           }
         ]
@@ -28,13 +28,13 @@ spark-bench = {
         descr = "KMeans serially with k = 3, 4"
         parallel = false
         repeat = 3
-        benchmark-output = "tmp/spark-bench-test/conf-file-output-2.parquet"
+        benchmark-output = "/tmp/spark-bench-scalatest/tmp/spark-bench-test/conf-file-output-2.parquet"
 
 
         workloads = [
           {
             name = [kmeans]
-            input = ["tmp/spark-bench-test/kmeans-data.parquet"]
+            input = ["/tmp/spark-bench-scalatest/tmp/spark-bench-test/kmeans-data.parquet"]
             k = [3, 4]
           }
         ]
@@ -55,7 +55,7 @@ spark-bench = {
             name = ["kmeans"]
             k = [1]
             seed = [96]
-            input = ["tmp/spark-bench-test/kmeans-data.parquet"]
+            input = ["/tmp/spark-bench-scalatest/tmp/spark-bench-test/kmeans-data.parquet"]
           }
         ]
       }

--- a/cli/src/test/resources/etc/testConfFile2.conf
+++ b/cli/src/test/resources/etc/testConfFile2.conf
@@ -10,17 +10,17 @@ spark-bench = {
         descr = "KMeans in parallel with k = 1, 2"
         parallel = true
         repeat = 5
-        benchmark-output = "tmp/spark-bench-test/conf-file-output-1.csv"
+        benchmark-output = "/tmp/spark-bench-scalatest/tmp/spark-bench-test/conf-file-output-1.csv"
 
         workloads = [
           {
             name = ["kmeans"]
-            input = ["tmp/spark-bench-test/kmeans-data.parquet"]
+            input = ["/tmp/spark-bench-scalatest/tmp/spark-bench-test/kmeans-data.parquet"]
             k = [1]
           },
           {
             name = ["kmeans"]
-            input = ["tmp/spark-bench-test/kmeans-data.parquet"]
+            input = ["/tmp/spark-bench-scalatest/tmp/spark-bench-test/kmeans-data.parquet"]
             k = [2]
           }
         ]
@@ -29,13 +29,13 @@ spark-bench = {
         descr = "KMeans serially with k = 3, 4"
         parallel = false
         repeat = 3
-        benchmark-output = "tmp/spark-bench-test/conf-file-output-2.parquet"
+        benchmark-output = "/tmp/spark-bench-scalatest/tmp/spark-bench-test/conf-file-output-2.parquet"
 
 
         workloads = [
           {
             name = [kmeans]
-            input = ["tmp/spark-bench-test/kmeans-data.parquet"]
+            input = ["/tmp/spark-bench-scalatest/tmp/spark-bench-test/kmeans-data.parquet"]
             k = [3, 4]
           }
         ]
@@ -56,7 +56,7 @@ spark-bench = {
             name = ["kmeans"]
             k = [1]
             seed = [96]
-            input = ["tmp/spark-bench-test/kmeans-data.parquet"]
+            input = ["/tmp/spark-bench-scalatest/tmp/spark-bench-test/kmeans-data.parquet"]
           }
         ]
       }

--- a/cli/src/test/scala/com/ibm/sparktc/sparkbench/NotebookSimTest.scala
+++ b/cli/src/test/scala/com/ibm/sparktc/sparkbench/NotebookSimTest.scala
@@ -12,9 +12,7 @@ class NotebookSimTest extends FlatSpec with Matchers with BeforeAndAfterEach wit
 
   override def beforeEach(): Unit = {
     super.beforeEach()
-    dataMaker.deleteFolders()
     dataMaker.createFolders()
-//    BuildAndTeardownData.deleteFilesStr(Seq(giantData, tinyData))
     dataMaker.generateKMeansData(400000, 50, giantData)
     dataMaker.generateKMeansData(100, 5, tinyData)
   }

--- a/cli/src/test/scala/com/ibm/sparktc/sparkbench/OutputTest.scala
+++ b/cli/src/test/scala/com/ibm/sparktc/sparkbench/OutputTest.scala
@@ -5,12 +5,10 @@ import com.ibm.sparktc.sparkbench.testfixtures.BuildAndTeardownData
 import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
 
 class OutputTest extends FlatSpec with Matchers with BeforeAndAfterAll with Capturing {
-
   val dataStuff = new BuildAndTeardownData("output-test")
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    dataStuff.deleteFolders()
     dataStuff.createFolders()
     dataStuff.generateKMeansData(1000, 5, dataStuff.kmeansFile)
   }

--- a/datageneration/src/test/scala/com/ibm/sparktc/sparkbench/datageneration/DataGenKickOffTest.scala
+++ b/datageneration/src/test/scala/com/ibm/sparktc/sparkbench/datageneration/DataGenKickOffTest.scala
@@ -12,7 +12,6 @@ class DataGenKickOffTest extends FlatSpec with Matchers with BeforeAndAfterEach 
   var file: File = _
 
   override def beforeEach() {
-    cool.deleteFolders()
     cool.createFolders()
     file = new File(filename)
   }

--- a/datageneration/src/test/scala/com/ibm/sparktc/sparkbench/datageneration/KMeansDataGenTest.scala
+++ b/datageneration/src/test/scala/com/ibm/sparktc/sparkbench/datageneration/KMeansDataGenTest.scala
@@ -17,7 +17,6 @@ class KMeansDataGenTest extends FlatSpec with Matchers with BeforeAndAfterEach {
   var file: File = _
 
   override def beforeEach() {
-    cool.deleteFolders()
     cool.createFolders()
     file = new File(fileName)
   }

--- a/datageneration/src/test/scala/com/ibm/sparktc/sparkbench/datageneration/LinearRegDataGenTest.scala
+++ b/datageneration/src/test/scala/com/ibm/sparktc/sparkbench/datageneration/LinearRegDataGenTest.scala
@@ -15,7 +15,6 @@ class LinearRegDataGenTest extends FlatSpec with Matchers with BeforeAndAfterEac
   var file: File = _
 
   override def beforeEach() {
-    cool.deleteFolders()
     file = new File(fileName)
     cool.createFolders()
   }

--- a/spark-launch/src/main/scala/com/ibm/sparktc/sparkbench/sparklaunch/SparkLaunch.scala
+++ b/spark-launch/src/main/scala/com/ibm/sparktc/sparkbench/sparklaunch/SparkLaunch.scala
@@ -54,7 +54,7 @@ object SparkLaunch extends App {
     }
   }
 
-  private def rmTmpFiles(fns: Seq[String]): Unit = fns.foreach { fn =>
+  private[sparklaunch] def rmTmpFiles(fns: Seq[String]): Unit = fns.foreach { fn =>
     try {
       val f = new File(fn)
       if (f.exists) f.delete

--- a/spark-launch/src/test/resources/etc/sparkConfTest.conf
+++ b/spark-launch/src/test/resources/etc/sparkConfTest.conf
@@ -17,17 +17,17 @@ spark-bench = {
         descr = "KMeans in parallel with k = 1, 2"
         parallel = true
         repeat = 5
-        benchmark-output = "tmp/spark-bench-test/conf-file-output-1.csv"
+        benchmark-output = "/tmp/spark-bench-scalatest/tmp/spark-bench-test/conf-file-output-1.csv"
 
         workloads = [
           {
             name = ["kmeans"]
-            input = ["tmp/spark-bench-test/kmeans-data.parquet"]
+            input = ["/tmp/spark-bench-scalatest/tmp/spark-bench-test/kmeans-data.parquet"]
             k = [1]
           },
           {
             name = ["kmeans"]
-            input = ["tmp/spark-bench-test/kmeans-data.parquet"]
+            input = ["/tmp/spark-bench-scalatest/tmp/spark-bench-test/kmeans-data.parquet"]
             k = [2]
           }
         ]
@@ -43,17 +43,17 @@ spark-bench = {
           descr = "KMeans in parallel with k = 1, 2"
           parallel = true
           repeat = 5
-          benchmark-output = "tmp/spark-bench-test/conf-file-output-1.csv"
+          benchmark-output = "/tmp/spark-bench-scalatest/tmp/spark-bench-test/conf-file-output-1.csv"
 
           workloads = [
             {
               name = ["kmeans"]
-              input = ["tmp/spark-bench-test/kmeans-data.parquet"]
+              input = ["/tmp/spark-bench-scalatest/tmp/spark-bench-test/kmeans-data.parquet"]
               k = [1]
             },
             {
               name = ["kmeans"]
-              input = ["tmp/spark-bench-test/kmeans-data.parquet"]
+              input = ["/tmp/spark-bench-scalatest/tmp/spark-bench-test/kmeans-data.parquet"]
               k = [2]
             }
           ]
@@ -62,13 +62,13 @@ spark-bench = {
           descr = "KMeans serially with k = 3, 4"
           parallel = false
           repeat = 3
-          benchmark-output = "tmp/spark-bench-test/conf-file-output-2.parquet"
+          benchmark-output = "/tmp/spark-bench-scalatest/tmp/spark-bench-test/conf-file-output-2.parquet"
 
 
           workloads = [
             {
               name = [kmeans]
-              input = ["tmp/spark-bench-test/kmeans-data.parquet"]
+              input = ["/tmp/spark-bench-scalatest/tmp/spark-bench-test/kmeans-data.parquet"]
               k = [3, 4]
             }
           ]
@@ -89,7 +89,7 @@ spark-bench = {
               name = ["kmeans"]
               k = [1]
               seed = [96]
-              input = ["tmp/spark-bench-test/kmeans-data.parquet"]
+              input = ["/tmp/spark-bench-scalatest/tmp/spark-bench-test/kmeans-data.parquet"]
             }
           ]
         }

--- a/spark-launch/src/test/resources/etc/testConfFile1.conf
+++ b/spark-launch/src/test/resources/etc/testConfFile1.conf
@@ -10,17 +10,17 @@ spark-bench = {
         descr = "KMeans in parallel with k = 1, 2"
         parallel = true
         repeat = 5
-        benchmark-output = "multi-spark/spark-bench-test/conf-file-output-1.csv"
+        benchmark-output = "/tmp/spark-bench-scalatest/multi-spark/spark-bench-test/conf-file-output-1.csv"
 
         workloads = [
           {
             name = ["kmeans"]
-            input = ["multi-spark/spark-bench-test/kmeans-data.parquet"]
+            input = ["/tmp/spark-bench-scalatest/multi-spark/spark-bench-test/kmeans-data.parquet"]
             k = [1]
           },
           {
             name = ["kmeans"]
-            input = ["multi-spark/spark-bench-test/kmeans-data.parquet"]
+            input = ["/tmp/spark-bench-scalatest/multi-spark/spark-bench-test/kmeans-data.parquet"]
             k = [2]
           }
         ]
@@ -29,13 +29,13 @@ spark-bench = {
         descr = "KMeans serially with k = 3, 4"
         parallel = false
         repeat = 3
-        benchmark-output = "multi-spark/spark-bench-test/conf-file-output-2.parquet"
+        benchmark-output = "/tmp/spark-bench-scalatest/multi-spark/spark-bench-test/conf-file-output-2.parquet"
 
 
         workloads = [
           {
             name = [kmeans]
-            input = ["multi-spark/spark-bench-test/kmeans-data.parquet"]
+            input = ["/tmp/spark-bench-scalatest/multi-spark/spark-bench-test/kmeans-data.parquet"]
             k = [3, 4]
           }
         ]
@@ -56,7 +56,7 @@ spark-bench = {
             name = ["kmeans"]
             k = [1]
             seed = [96]
-            input = ["multi-spark/spark-bench-test/kmeans-data.parquet"]
+            input = ["/tmp/spark-bench-scalatest/multi-spark/spark-bench-test/kmeans-data.parquet"]
           }
         ]
       }

--- a/spark-launch/src/test/scala/com/ibm/sparktc/sparkbench/sparklaunch/SparkLaunchConfTest.scala
+++ b/spark-launch/src/test/scala/com/ibm/sparktc/sparkbench/sparklaunch/SparkLaunchConfTest.scala
@@ -28,6 +28,8 @@ class SparkLaunchConfTest extends FlatSpec with Matchers with BeforeAndAfter {
 
     conf1.sparkConfs shouldBe expectedSparkConfs
 
+    SparkLaunch.rmTmpFiles(sparkContextConfs.map(_._2))
+
 //    val resultConf = conf1.createSparkContext().sparkContext.getConf
 //    resultConf.getBoolean("spark.dynamicAllocation.enabled", defaultValue = true) shouldBe false
 //    resultConf.getBoolean("spark.shuffle.service.enabled", defaultValue = true) shouldBe false
@@ -42,6 +44,7 @@ class SparkLaunchConfTest extends FlatSpec with Matchers with BeforeAndAfter {
 
     conf2.sparkConfs.isEmpty shouldBe true
 
+    SparkLaunch.rmTmpFiles(sparkContextConfs.map(_._2))
   }
 
 }

--- a/spark-launch/src/test/scala/com/ibm/sparktc/sparkbench/sparklaunch/SparkLaunchOneSparkContextPerRunTest.scala
+++ b/spark-launch/src/test/scala/com/ibm/sparktc/sparkbench/sparklaunch/SparkLaunchOneSparkContextPerRunTest.scala
@@ -8,7 +8,6 @@ class SparkLaunchOneSparkContextPerRunTest extends FlatSpec with Matchers with B
 
   override def beforeEach(): Unit = {
     super.beforeEach()
-    dataShiznit.deleteFolders()
     dataShiznit.createFolders()
     dataShiznit.generateKMeansData(1000, 5, dataShiznit.kmeansFile)
   }

--- a/spark-launch/src/test/scala/com/ibm/sparktc/sparkbench/sparklaunch/SparkLaunchTest.scala
+++ b/spark-launch/src/test/scala/com/ibm/sparktc/sparkbench/sparklaunch/SparkLaunchTest.scala
@@ -8,7 +8,6 @@ class SparkLaunchTest extends FlatSpec with Matchers with BeforeAndAfterEach {
 
   override def beforeEach(): Unit = {
     super.beforeEach()
-    dataShiznit.deleteFolders()
     dataShiznit.createFolders()
     dataShiznit.generateKMeansData(1000, 5, dataShiznit.kmeansFile)
   }

--- a/utils/src/test/scala/com/ibm/sparktc/sparkbench/testfixtures/BuildAndTeardownData.scala
+++ b/utils/src/test/scala/com/ibm/sparktc/sparkbench/testfixtures/BuildAndTeardownData.scala
@@ -10,9 +10,10 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.{DoubleType, StructField, StructType}
 
-class BuildAndTeardownData(prefix: String) {
+class BuildAndTeardownData(dirname: String = System.currentTimeMillis.toString) {
+  val prefix = "/tmp/spark-bench-scalatest/" + dirname
   val sparkBenchTestFolder = s"$prefix/spark-bench-test"
-  val kmeansFile = s"${sparkBenchTestFolder}/kmeans-data.parquet"
+  val kmeansFile = s"$sparkBenchTestFolder/kmeans-data.parquet"
   val sparkBenchDemoFolder = s"$prefix/spark-bench-demo"
   val spark = SparkSessionProvider.spark
 
@@ -22,8 +23,6 @@ class BuildAndTeardownData(prefix: String) {
   }
 
   def deleteFolders(): Unit = {
-//    val fileSeq = Seq(new File(sparkBenchTestFolder), new File(sparkBenchDemoFolder))
-//    fileSeq.foreach(folder => Utils.deleteRecursively(folder))
     Utils.deleteRecursively(new File(prefix))
   }
 
@@ -48,5 +47,4 @@ class BuildAndTeardownData(prefix: String) {
 
     writeToDisk(outputFile, df, spark)
   }
-
 }

--- a/utils/src/test/scala/com/ibm/sparktc/sparkbench/testfixtures/Fixtures.scala
+++ b/utils/src/test/scala/com/ibm/sparktc/sparkbench/testfixtures/Fixtures.scala
@@ -1,7 +1,0 @@
-package com.ibm.sparktc.sparkbench.testfixtures
-
-object Fixtures {
-
-  val buttz = "buttz"
-
-}

--- a/workloads/src/test/scala/com/ibm/sparktc/sparkbench/workload/sql/SQLWorkloadTest.scala
+++ b/workloads/src/test/scala/com/ibm/sparktc/sparkbench/workload/sql/SQLWorkloadTest.scala
@@ -4,7 +4,6 @@ import com.ibm.sparktc.sparkbench.testfixtures.{BuildAndTeardownData, SparkSessi
 import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
 
 class SQLWorkloadTest extends FlatSpec with Matchers with BeforeAndAfterAll {
-  
   val ioStuff = new BuildAndTeardownData("sql-workload")
   
   val spark = SparkSessionProvider.spark
@@ -14,15 +13,13 @@ class SQLWorkloadTest extends FlatSpec with Matchers with BeforeAndAfterAll {
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    ioStuff.deleteFolders()
     ioStuff.createFolders()
-//    ioStuff.deleteFilesStr(Seq(smallData))
     ioStuff.generateKMeansData(1000, 10, smallData)
   }
 
   override def afterAll(): Unit = {
-    super.afterAll()
     ioStuff.deleteFolders()
+    super.afterAll()
   }
 
   "Sql Queries over generated kmeans data" should "work" in {
@@ -35,6 +32,4 @@ class SQLWorkloadTest extends FlatSpec with Matchers with BeforeAndAfterAll {
 
     workload.doWorkload(None, spark)
   }
-
-
 }


### PR DESCRIPTION
I've moved all temporary directories created during testing to `/tmp/spark-bench-scalatest`.  They should be deleted automatically during testing, but in the event that a test fails or is canceled, they will hang out there and get deleted by the next run of `sbt clean`.  (Tests fail if the files are not cleaned up.)  I've also added cleanup of created temporary configuration files to `SparkLaunchConfTest`.