### PR TITLE
Add `spark-home` to config file

### DIFF
--- a/bin/spark-bench.sh
+++ b/bin/spark-bench.sh
@@ -5,20 +5,9 @@ BASEDIR=$(dirname "$WHEREILIVE")
 PARENTDIR=$(dirname "$BASEDIR")
 
 [[ -f "$BASEDIR/spark-bench-env.sh" ]] && source "$BASEDIR/spark-bench-env.sh"
-[[ -z "$SPARK_HOME" ]] && echo "[ERROR] Please set the environment variable SPARK_HOME in bin/spark-bench-env.sh" && exit 1
-[[ -f "$SPARK_HOME/conf/spark-env.sh" ]] && source "$SPARK_HOME/conf/spark-env.sh"
 
 SPARK_BENCH_LAUNCH_JAR=$(ls "$PARENTDIR"/lib/spark-bench-launch*.jar)
 MAIN_CLASS="com.ibm.sparktc.sparkbench.sparklaunch.SparkLaunch"
 SPARK_BENCH_JAR=$(ls "$PARENTDIR"/lib/spark-bench-[0-9]*.jar)
-#SPARK_BENCH_CLASSPATH="$SPARK_BENCH_JAR"
-
-#for dir in "$SPARK_HOME/lib" "$SPARK_HOME/jars" "$WORKLOAD_DIR"
-#    do [[ -d "$dir" ]] && echo "Found $dir" && SPARK_BENCH_CLASSPATH+=":$dir/*"
-#done
-
-#echo "SPARK_BENCH_CLASSPATH is $SPARK_BENCH_CLASSPATH"
-echo "MAIN_CLASS is $MAIN_CLASS"
-#export SPARK_BENCH_CLASSPATH
 
 java -cp "$SPARK_BENCH_LAUNCH_JAR" "$MAIN_CLASS" "$@"

--- a/spark-launch/src/main/scala/com/ibm/sparktc/sparkbench/sparklaunch/SparkLaunch.scala
+++ b/spark-launch/src/main/scala/com/ibm/sparktc/sparkbench/sparklaunch/SparkLaunch.scala
@@ -1,6 +1,5 @@
 package com.ibm.sparktc.sparkbench.sparklaunch
 
-import com.ibm.sparktc.sparkbench.utils.GeneralFunctions.getOrThrow
 import com.typesafe.config._
 import java.io.File
 import scala.collection.parallel.ForkJoinTaskSupport
@@ -42,11 +41,9 @@ object SparkLaunch extends App {
 
   def launch(conf: SparkLaunchConf): Unit = {
     val argz: Array[String] = conf.toSparkArgs
-    val sparkHome = getOrThrow(sys.env.get("SPARK_HOME"), "The environment variable SPARK_HOME must be set")
-    val submitCmd = (Seq(s"$sparkHome/bin/spark-submit") ++ argz).mkString(" ")
-    println(s" *** SPARK-SUBMIT: $submitCmd")
-    val returnCode: Int = submitCmd.!
-    if (returnCode != 0) {
+    val submitProc = Process(Seq(s"${conf.sparkHome}/bin/spark-submit") ++ argz, None, "SPARK_HOME" -> conf.sparkHome)
+    println(" *** SPARK-SUBMIT: " + submitProc.toString)
+    if (submitProc.! != 0) {
       throw new Exception(s"spark-submit failed to complete properly given these arguments: \n\t${argz.mkString(" ")}")
     }
   }

--- a/spark-launch/src/test/scala/com/ibm/sparktc/sparkbench/sparklaunch/SparkLaunchConfTest.scala
+++ b/spark-launch/src/test/scala/com/ibm/sparktc/sparkbench/sparklaunch/SparkLaunchConfTest.scala
@@ -21,9 +21,9 @@ class SparkLaunchConfTest extends FlatSpec with Matchers with BeforeAndAfter {
     val conf1 = sparkContextConfs.head._1
 
     val expectedSparkConfs = Array(
-      "--conf spark.shuffle.service.enabled=false",
-      "--conf spark.fake=yes",
-      "--conf spark.dynamicAllocation.enabled=false"
+      "--conf", "spark.shuffle.service.enabled=false",
+      "--conf", "spark.fake=yes",
+      "--conf", "spark.dynamicAllocation.enabled=false"
     )
 
     conf1.sparkConfs shouldBe expectedSparkConfs


### PR DESCRIPTION
SparkLaunch will now look at the config file for a `spark-home` parameter before falling back to the `SPARK_HOME` environment variable.  I also converted the submit command construction from a string to a more robust Seq of strings.