### PR TITLE
Add --dryrun flag to skip doWorkload

### DIFF
--- a/cli/src/main/scala/com/ibm/sparktc/sparkbench/cli/Configurator.scala
+++ b/cli/src/main/scala/com/ibm/sparktc/sparkbench/cli/Configurator.scala
@@ -17,6 +17,7 @@ object Configurator {
     val config: Config = ConfigFactory.parseFile(file)
     val sparkBenchConfig = config.getObject("spark-bench").toConfig
     val sparkContextConfs = parseSparkBenchRunConfig(sparkBenchConfig)
+    GlobalConfig.fromConf(sparkBenchConfig)
     sparkContextConfs
   }
 

--- a/cli/src/main/scala/com/ibm/sparktc/sparkbench/cli/GlobalConfig.scala
+++ b/cli/src/main/scala/com/ibm/sparktc/sparkbench/cli/GlobalConfig.scala
@@ -1,0 +1,13 @@
+package com.ibm.sparktc.sparkbench.cli
+
+import com.typesafe.config.Config
+
+import scala.util.Try
+
+object GlobalConfig {
+  var dryRun: Boolean = false
+
+  def fromConf(config: Config): Unit = {
+    Try(config.getBoolean("dry-run")).foreach(dryRun = _)
+  }
+}

--- a/cli/src/main/scala/com/ibm/sparktc/sparkbench/workload/SuiteKickoff.scala
+++ b/cli/src/main/scala/com/ibm/sparktc/sparkbench/workload/SuiteKickoff.scala
@@ -71,11 +71,11 @@ object SuiteKickoff {
   private def runParallel(workloadConfigs: Seq[Workload], spark: SparkSession): Seq[DataFrame] = {
     val confSeqPar = workloadConfigs.par
     confSeqPar.tasksupport = new ForkJoinTaskSupport(new scala.concurrent.forkjoin.ForkJoinPool(confSeqPar.size))
-    confSeqPar.map(_.run(spark)).seq
+    confSeqPar.map(_.run(spark, false)).seq
   }
 
   private def runSerially(workloadConfigs: Seq[Workload], spark: SparkSession): Seq[DataFrame] = {
-    workloadConfigs.map(_.run(spark))
+    workloadConfigs.map(_.run(spark, false))
   }
 
   private def joinDataFrames(seq: Seq[DataFrame], spark: SparkSession): DataFrame = {

--- a/cli/src/main/scala/com/ibm/sparktc/sparkbench/workload/SuiteKickoff.scala
+++ b/cli/src/main/scala/com/ibm/sparktc/sparkbench/workload/SuiteKickoff.scala
@@ -1,5 +1,6 @@
 package com.ibm.sparktc.sparkbench.workload
 
+import com.ibm.sparktc.sparkbench.cli.GlobalConfig
 import com.ibm.sparktc.sparkbench.utils.SparkFuncs.{writeToDisk, addConfToResults}
 import org.apache.spark.sql.{DataFrame, Row, SparkSession}
 import org.apache.spark.sql.functions.{col, lit}
@@ -71,11 +72,11 @@ object SuiteKickoff {
   private def runParallel(workloadConfigs: Seq[Workload], spark: SparkSession): Seq[DataFrame] = {
     val confSeqPar = workloadConfigs.par
     confSeqPar.tasksupport = new ForkJoinTaskSupport(new scala.concurrent.forkjoin.ForkJoinPool(confSeqPar.size))
-    confSeqPar.map(_.run(spark, false)).seq
+    confSeqPar.map(_.run(spark, GlobalConfig.dryRun)).seq
   }
 
   private def runSerially(workloadConfigs: Seq[Workload], spark: SparkSession): Seq[DataFrame] = {
-    workloadConfigs.map(_.run(spark, false))
+    workloadConfigs.map(_.run(spark, GlobalConfig.dryRun))
   }
 
   private def joinDataFrames(seq: Seq[DataFrame], spark: SparkSession): DataFrame = {

--- a/cli/src/main/scala/com/ibm/sparktc/sparkbench/workload/Workload.scala
+++ b/cli/src/main/scala/com/ibm/sparktc/sparkbench/workload/Workload.scala
@@ -1,7 +1,8 @@
 package com.ibm.sparktc.sparkbench.workload
 
-import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.sql.{DataFrame, Row, SparkSession}
 import com.ibm.sparktc.sparkbench.utils.SparkFuncs.{load, addConfToResults}
+import org.apache.spark.sql.types.StructType
 
 trait WorkloadDefaults {
   val name: String
@@ -25,9 +26,10 @@ trait Workload {
     */
   def doWorkload(df: Option[DataFrame], sparkSession: SparkSession): DataFrame
 
-  def run(spark: SparkSession, dryRun: Boolean): DataFrame = {
+  def run(spark: SparkSession, dryRun: Boolean = false): DataFrame = {
     val res = if (dryRun) {
-      spark.emptyDataFrame
+      // DataFrame with one row and no columns
+      spark.createDataFrame(spark.sparkContext.parallelize(Seq(Row())), StructType(Seq()))
     }
     else {
       val df = input match {

--- a/cli/src/main/scala/com/ibm/sparktc/sparkbench/workload/Workload.scala
+++ b/cli/src/main/scala/com/ibm/sparktc/sparkbench/workload/Workload.scala
@@ -25,17 +25,20 @@ trait Workload {
     */
   def doWorkload(df: Option[DataFrame], sparkSession: SparkSession): DataFrame
 
-  def run(spark: SparkSession): DataFrame = {
-
-    val df = input match {
-      case None => None
-      case Some(in) => {
-        val rawDF = load(spark, in)
-        Some(reconcileSchema(rawDF))
-      }
+  def run(spark: SparkSession, dryRun: Boolean): DataFrame = {
+    val res = if (dryRun) {
+      spark.emptyDataFrame
     }
-
-    val res = doWorkload(df, spark).coalesce(1)
+    else {
+      val df = input match {
+        case None => None
+        case Some(in) => {
+          val rawDF = load(spark, in)
+          Some(reconcileSchema(rawDF))
+        }
+      }
+      doWorkload(df, spark).coalesce(1)
+    }
     addConfToResults(res, toMap)
   }
 

--- a/cli/src/main/scala/com/ibm/sparktc/sparkbench/workload/exercise/CacheTest.scala
+++ b/cli/src/main/scala/com/ibm/sparktc/sparkbench/workload/exercise/CacheTest.scala
@@ -4,7 +4,7 @@ import com.ibm.sparktc.sparkbench.workload.{Workload, WorkloadDefaults}
 import com.ibm.sparktc.sparkbench.utils.GeneralFunctions._
 import org.apache.spark.sql.{DataFrame, SparkSession}
 
-case class CacheTestResult(name: String, timestamp: Long, runTime1: Long, runTime2: Long, runTime3: Long)
+case class CacheTestResult(runTime1: Long, runTime2: Long, runTime3: Long)
 
 object CacheTest extends WorkloadDefaults {
   val name = "cachetest"
@@ -29,7 +29,6 @@ case class CacheTest(input: Option[String],
     Thread.sleep(sleepMs)
     val (resultTime3, _) = time(cached.count)
 
-    val now = System.currentTimeMillis()
-    spark.createDataFrame(Seq(CacheTestResult("cachetest", now, resultTime1, resultTime2, resultTime3)))
+    spark.createDataFrame(Seq(CacheTestResult(resultTime1, resultTime2, resultTime3)))
   }
 }

--- a/cli/src/main/scala/com/ibm/sparktc/sparkbench/workload/exercise/PartitionAndSleepWorkload.scala
+++ b/cli/src/main/scala/com/ibm/sparktc/sparkbench/workload/exercise/PartitionAndSleepWorkload.scala
@@ -3,8 +3,8 @@ package com.ibm.sparktc.sparkbench.workload.exercise
 import com.ibm.sparktc.sparkbench.workload.{Workload, WorkloadDefaults}
 import org.apache.spark.sql.{DataFrame, Row, SparkSession}
 import com.ibm.sparktc.sparkbench.utils.GeneralFunctions._
+import com.ibm.sparktc.sparkbench.utils.SparkFuncs
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.types.{LongType, StringType, StructField, StructType}
 
 object PartitionAndSleepWorkload extends WorkloadDefaults {
   val name = "timedsleep"
@@ -23,7 +23,7 @@ case class PartitionAndSleepWorkload(input: Option[String] = None,
                                      partitions: Int,
                                      sleepMS: Long) extends Workload {
 
-  def doStuff(spark: SparkSession): (Long, Unit) = time {
+  def doStuff(spark: SparkSession): Unit = {
 
     val ms = sleepMS
     val stuff: RDD[Int] = spark.sparkContext.parallelize(0 until partitions * 100, partitions)
@@ -38,19 +38,8 @@ case class PartitionAndSleepWorkload(input: Option[String] = None,
   }
 
   override def doWorkload(df: Option[DataFrame] = None, spark: SparkSession): DataFrame = {
-    val (t, _) = doStuff(spark)
-
-    val schema = StructType(
-      List(
-        StructField("name", StringType, nullable = false),
-        StructField("timestamp", LongType, nullable = false),
-        StructField("runtime", LongType, nullable = false)
-      )
-    )
-
-    val timeList = spark.sparkContext.parallelize(Seq(Row("timedsleep", System.currentTimeMillis(), t)))
-
-    spark.createDataFrame(timeList, schema)
+    doStuff(spark)
+    SparkFuncs.zeroColRes(spark)
   }
 }
 

--- a/cli/src/main/scala/com/ibm/sparktc/sparkbench/workload/exercise/Sleep.scala
+++ b/cli/src/main/scala/com/ibm/sparktc/sparkbench/workload/exercise/Sleep.scala
@@ -2,13 +2,8 @@ package com.ibm.sparktc.sparkbench.workload.exercise
 
 import com.ibm.sparktc.sparkbench.workload.{Workload, WorkloadDefaults}
 import com.ibm.sparktc.sparkbench.utils.GeneralFunctions._
+import com.ibm.sparktc.sparkbench.utils.SparkFuncs
 import org.apache.spark.sql.{DataFrame, SparkSession}
-
-case class SleepResult(
-                      name: String,
-                      timestamp: Long,
-                      total_runtime: Long
-                      )
 
 object Sleep extends WorkloadDefaults {
   val name = "sleep"
@@ -30,12 +25,8 @@ case class Sleep(
               ) extends Workload {
 
   override def doWorkload(df: Option[DataFrame] = None, spark: SparkSession): DataFrame = {
-    val timestamp = System.currentTimeMillis()
-    val (t, _) = time {
-      Thread.sleep(sleepMS)
-    }
-
-    spark.createDataFrame(Seq(SleepResult("sleep", timestamp, t)))
+    Thread.sleep(sleepMS)
+    SparkFuncs.zeroColRes(spark)
   }
 
 }

--- a/cli/src/main/scala/com/ibm/sparktc/sparkbench/workload/exercise/SparkPi.scala
+++ b/cli/src/main/scala/com/ibm/sparktc/sparkbench/workload/exercise/SparkPi.scala
@@ -6,13 +6,7 @@ import org.apache.spark.sql.{DataFrame, SparkSession}
 
 import scala.math.random
 
-
-case class SparkPiResult(
-                        name: String,
-                        timestamp: Long,
-                        total_runtime: Long,
-                        pi_approximate: Double
-                      )
+case class SparkPiResult(pi_approximate: Double)
 
 object SparkPi extends WorkloadDefaults {
   val name = "sparkpi"
@@ -42,9 +36,7 @@ case class SparkPi(input: Option[String] = None,
   }
 
   override def doWorkload(df: Option[DataFrame] = None, spark: SparkSession): DataFrame = {
-    val timestamp = System.currentTimeMillis()
-    val (t, pi) = time(sparkPi(spark))
-    spark.createDataFrame(Seq(SparkPiResult("sparkpi", timestamp, t, pi)))
+    spark.createDataFrame(Seq(SparkPiResult(sparkPi(spark))))
   }
 
 }

--- a/cli/src/main/scala/com/ibm/sparktc/sparkbench/workload/ml/LogisticRegressionWorkload.scala
+++ b/cli/src/main/scala/com/ibm/sparktc/sparkbench/workload/ml/LogisticRegressionWorkload.scala
@@ -13,9 +13,7 @@ import org.apache.spark.sql.{DataFrame, Row, SparkSession}
 // ¯\_(ツ)_/¯
 
 case class LogisticRegressionResult(
-                                     name: String,
                                      appid: String,
-                                     start_time: Long,
                                      input: String,
                                      train_count: Long,
                                      train_time: Long,
@@ -24,7 +22,6 @@ case class LogisticRegressionResult(
                                      test_time: Long,
                                      load_time: Long,
                                      count_time: Long,
-                                     total_runtime: Long,
                                      area_under_roc: Double
                                    )
 
@@ -66,7 +63,6 @@ case class LogisticRegressionWorkload(
   }
 
   override def doWorkload(df: Option[DataFrame], spark: SparkSession): DataFrame = {
-    val startTime = System.currentTimeMillis
     val (ltrainTime, d_train) = ld(s"${input.get}")(spark)
     val (ltestTime, d_test) = ld(s"$testFile")(spark)
     val (countTime, (trainCount, testCount)) = time { (d_train.count(), d_test.count()) }
@@ -78,9 +74,7 @@ case class LogisticRegressionWorkload(
     //spark.createDataFrame(Seq(SleepResult("sleep", timestamp, t)))
 
     spark.createDataFrame(Seq(LogisticRegressionResult(
-      name = "lr-bml",
       appid = spark.sparkContext.applicationId,
-      startTime,
       input.get,
       train_count = trainCount,
       trainTime,
@@ -89,7 +83,6 @@ case class LogisticRegressionWorkload(
       testTime,
       loadTime,
       countTime,
-      loadTime + trainTime + testTime,
       areaUnderROC
     )))
   }

--- a/cli/src/main/scala/com/ibm/sparktc/sparkbench/workload/sql/SQLWorkload.scala
+++ b/cli/src/main/scala/com/ibm/sparktc/sparkbench/workload/sql/SQLWorkload.scala
@@ -6,12 +6,9 @@ import com.ibm.sparktc.sparkbench.workload.{Workload, WorkloadDefaults}
 import org.apache.spark.sql.{DataFrame, SparkSession}
 
 case class SQLWorkloadResult(
-                            name: String,
-                            timestamp: Long,
                             loadTime: Long,
                             queryTime: Long,
-                            saveTime: Long = 0L,
-                            total_Runtime: Long
+                            saveTime: Long = 0L
                             )
 
 object SQLWorkload extends WorkloadDefaults {
@@ -46,26 +43,19 @@ case class SQLWorkload (input: Option[String],
   }
 
   override def doWorkload(df: Option[DataFrame] = None, spark: SparkSession): DataFrame = {
-    val timestamp = System.currentTimeMillis()
     val (loadtime, df) = loadFromDisk(spark)
     val (querytime, res) = query(df, spark)
     val (savetime, _) = output match {
       case Some(dir) => save(res, dir, spark)
       case _ => (0L, Unit)
     }
-    val total = loadtime + querytime + savetime
-
     spark.createDataFrame(Seq(
       SQLWorkloadResult(
-        "sql",
-        timestamp,
         loadtime,
         querytime,
-        savetime,
-        total
+        savetime
       )
     ))
   }
 
 }
-

--- a/cli/src/test/scala/com/ibm/sparktc/sparkbench/workload/exercise/PartitionAndSleepWorkloadTest.scala
+++ b/cli/src/test/scala/com/ibm/sparktc/sparkbench/workload/exercise/PartitionAndSleepWorkloadTest.scala
@@ -8,11 +8,11 @@ class PartitionAndSleepWorkloadTest extends FlatSpec with Matchers {
 
   "PartitionAndSleepWorkload" should "instantiate and run" in {
     val workload = PartitionAndSleepWorkload(Map("name" -> "timedsleep", "partitions" -> 10, "sleepms" -> 10))
-    val res = workload.doWorkload(None, spark).collect
+    val res = workload.run(spark).collect
     res.length shouldBe 1
     val row  = res(0)
-    row.length shouldBe 3
-    row.getAs[String]("name") shouldBe "timedsleep"
-    row.getAs[Long]("timestamp") shouldBe System.currentTimeMillis +- 10000
+    row.length shouldBe 7
+    //row.getAs[String]("name") shouldBe "name"
+    row.getAs[Long]("start_time") shouldBe System.currentTimeMillis +- 10000
   }
 }

--- a/cli/src/test/scala/com/ibm/sparktc/sparkbench/workload/exercise/SparkPiTest.scala
+++ b/cli/src/test/scala/com/ibm/sparktc/sparkbench/workload/exercise/SparkPiTest.scala
@@ -8,11 +8,11 @@ class SparkPiTest extends FlatSpec with Matchers with BeforeAndAfterEach {
 
   "SparkPi" should "instantiate and run" in {
     val workload = SparkPi(Map("slices" -> 4))
-    val res = workload.doWorkload(None, spark).collect
+    val res = workload.run(spark).collect
     res.length shouldBe 1
     val row = res(0)
-    row.length shouldBe 4
-    row.getAs[String]("name") shouldBe "sparkpi"
+    row.length shouldBe 7
+    //row.getAs[String]("name") shouldBe "sparkpi"
     row.getAs[Double]("pi_approximate") shouldBe 3.14 +- 1
   }
 
@@ -20,7 +20,7 @@ class SparkPiTest extends FlatSpec with Matchers with BeforeAndAfterEach {
     val res = SparkPi(Map("slices" -> 4)).run(spark, true).collect
     res.length shouldBe 1
     val cols = res(0).schema.toList.map(_.name)
-    cols.length shouldBe 3
+    cols.length shouldBe 6
     cols should not contain "pi_approximate"
   }
 }

--- a/cli/src/test/scala/com/ibm/sparktc/sparkbench/workload/exercise/SparkPiTest.scala
+++ b/cli/src/test/scala/com/ibm/sparktc/sparkbench/workload/exercise/SparkPiTest.scala
@@ -7,12 +7,20 @@ class SparkPiTest extends FlatSpec with Matchers with BeforeAndAfterEach {
   val spark = SparkSessionProvider.spark
 
   "SparkPi" should "instantiate and run" in {
-    val workload = SparkPi(Map("name" -> "sparkpi", "slices" -> 4))
+    val workload = SparkPi(Map("slices" -> 4))
     val res = workload.doWorkload(None, spark).collect
     res.length shouldBe 1
     val row = res(0)
     row.length shouldBe 4
     row.getAs[String]("name") shouldBe "sparkpi"
     row.getAs[Double]("pi_approximate") shouldBe 3.14 +- 1
+  }
+
+  "SparkPi" should "do a dry run properly" in {
+    val res = SparkPi(Map("slices" -> 4)).run(spark, true).collect
+    res.length shouldBe 1
+    val cols = res(0).schema.toList.map(_.name)
+    cols.length shouldBe 3
+    cols should not contain "pi_approximate"
   }
 }

--- a/cli/src/test/scala/com/ibm/sparktc/sparkbench/workload/ml/LogisticRegressionWorkloadTest.scala
+++ b/cli/src/test/scala/com/ibm/sparktc/sparkbench/workload/ml/LogisticRegressionWorkloadTest.scala
@@ -73,7 +73,6 @@ class LogisticRegressionWorkloadTest extends FlatSpec with Matchers {
     val odf = lr.doWorkload(Some(ds), spark)
     odf.count shouldBe 1
     val r = odf.head
-    r.getAs[String]("name") shouldBe "lr-bml"
     r.getAs[String]("input") shouldBe input
     r.getAs[String]("test_file") shouldBe testFile
     r.getAs[Long]("train_count") shouldBe 10L

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -17,6 +17,9 @@ Contributions welcome!
 spark-bench is a multi-project SBT build. The build is mainly defined in [build.sbt](../build.sbt) and dependencies
 are defined in [Dependencies.scala](../project/Dependencies.scala).
 
+Note that to run tests with `sbt test`, the `SPARK_HOME` environment variable must be set to an installation of Spark,
+just like for any other invocation of spark-bench.
+
 ## Adding a New Data Generator
 
 All the data generators live in the data generator project. Let's add a new data generator called FooGenerator.

--- a/readme.md
+++ b/readme.md
@@ -56,9 +56,10 @@ this is just one. I recommend adding the following line to your bash_profile:
 ```bash
 export SBT_OPTS="-Xmx1536M -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=2G -Xss2M"
 ```
-Now you're ready to test spark-bench, if you so desire.
+Now you're ready to test spark-bench, if you so desire.  Running tests requires Spark to be installed and the
+`SPARK_HOME` environment variable to be set, so make sure you take care of that before testing.
 ```bash
-sbt test
+SPARK_HOME=/path/to/spark sbt test
 ```
 And finally to build the distribution folder and associated tar file.
 ```bash

--- a/spark-launch/src/main/scala/com/ibm/sparktc/sparkbench/sparklaunch/ConfigWrangler.scala
+++ b/spark-launch/src/main/scala/com/ibm/sparktc/sparkbench/sparklaunch/ConfigWrangler.scala
@@ -30,7 +30,7 @@ object ConfigWrangler {
     * @param path
     * @return a Seq of paths to the created files.
     */
-  def apply(path: File): Seq[(SparkLaunchConf, String)] = {
+  def apply(path: File, dryRun: Boolean): Seq[(SparkLaunchConf, String)] = {
     val config: Config = ConfigFactory.parseFile(path)
     val sparkBenchConfig = config.getObject("spark-bench").toConfig
     val sparkContextConfs = getConfigListByName("spark-submit-config", sparkBenchConfig)
@@ -41,6 +41,7 @@ object ConfigWrangler {
       val newConf = sparkBenchConfig
         .withoutPath("spark-submit-config")
         .withValue("spark-submit-config", ConfigValueFactory.fromIterable(Iterable(conf.root).asJava))
+        .withValue("dry-run", ConfigValueFactory.fromAnyRef(dryRun))
       val sbConf = ConfigFactory.empty.withValue("spark-bench", newConf.root)
       val output = sbConf.root.render(concise.setJson(false))
       Files.write(tmpFile, output.getBytes(), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)

--- a/spark-launch/src/main/scala/com/ibm/sparktc/sparkbench/sparklaunch/SparkLaunchConf.scala
+++ b/spark-launch/src/main/scala/com/ibm/sparktc/sparkbench/sparklaunch/SparkLaunchConf.scala
@@ -41,14 +41,6 @@ object SparkLaunchConf {
   def getSparkArgs(sparkContextConf: Config): Array[String] = {
     val sparkConfMaps = Try(sparkContextConf.getObject("spark-args")).map(toStringMap).getOrElse(Map.empty)
 
-    /*val cp = {
-      if (sparkConfMaps.contains("driver-class-path")) Map.empty
-      else sys.env.get("SPARK_BENCH_CLASSPATH") match {
-        case Some(envCp) => Map("driver-class-path" -> envCp)
-        case _ => Map.empty
-      }
-    }*/
-
     val master = {
       if (sparkConfMaps.contains("master")) Map.empty
       else Map("master" -> getOrThrow(sys.env.get("SPARK_MASTER_HOST"), "The environment variable SPARK_MASTER_HOST must be set"))

--- a/spark-launch/src/test/scala/com/ibm/sparktc/sparkbench/sparklaunch/SparkLaunchConfTest.scala
+++ b/spark-launch/src/test/scala/com/ibm/sparktc/sparkbench/sparklaunch/SparkLaunchConfTest.scala
@@ -17,7 +17,7 @@ class SparkLaunchConfTest extends FlatSpec with Matchers with BeforeAndAfter {
     val relativePath = "/etc/sparkConfTest.conf"
     val resource = new File(getClass.getResource(relativePath).toURI)
 //    val source = scala.io.Source.fromFile(resource)
-    val (sparkContextConfs, _) = SparkLaunch.mkConfs(resource)
+    val (sparkContextConfs, _) = SparkLaunch.mkConfs(resource, dryRun = false)
     val conf1 = sparkContextConfs.head._1
 
     val expectedSparkConfs = Array(
@@ -39,7 +39,7 @@ class SparkLaunchConfTest extends FlatSpec with Matchers with BeforeAndAfter {
   it should "not blow up when spark context confs are left out" in {
     val relativePath = "/etc/testConfFile1.conf"
     val resource = new File(getClass.getResource(relativePath).toURI)
-    val (sparkContextConfs, _) = SparkLaunch.mkConfs(resource)
+    val (sparkContextConfs, _) = SparkLaunch.mkConfs(resource, dryRun = false)
     val conf2 = sparkContextConfs.head._1
 
     conf2.sparkConfs.isEmpty shouldBe true

--- a/utils/src/main/scala/com/ibm/sparktc/sparkbench/utils/SparkFuncs.scala
+++ b/utils/src/main/scala/com/ibm/sparktc/sparkbench/utils/SparkFuncs.scala
@@ -1,7 +1,8 @@
 package com.ibm.sparktc.sparkbench.utils
 
 import org.apache.spark.sql.functions.lit
-import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.{DataFrame, Row, SparkSession}
 
 object SparkFuncs {
 
@@ -23,6 +24,10 @@ object SparkFuncs {
         s"Please check the file extension or add a file format to your arguments: $outputDir")
     }
   }
+
+  def zeroColRes(spark: SparkSession): DataFrame =
+    // DataFrame with one row and no columns
+    spark.createDataFrame(spark.sparkContext.parallelize(Seq(Row())), StructType(Seq()))
 
   def load(spark: SparkSession, inputDir: String, fileFormat: Option[String] = None): DataFrame = {
 

--- a/utils/src/main/scala/com/ibm/sparktc/sparkbench/utils/SparkFuncs.scala
+++ b/utils/src/main/scala/com/ibm/sparktc/sparkbench/utils/SparkFuncs.scala
@@ -60,9 +60,9 @@ object SparkFuncs {
       case _ => a
     }
 
-    var ddf: DataFrame = df
-    m.foreach( keyValue => ddf = ddf.withColumn(keyValue._1, lit(dealWithNones(keyValue._2))) )
-    ddf
+   m.foldLeft(df) {
+      (partial, keyval) => partial.withColumn(keyval._1, lit(dealWithNones(keyval._2)))
+    }
   }
 
 }


### PR DESCRIPTION
Resolves #61.  If the `--dryrun` flag is added on the command line, the program will run the same but will skip running the workloads and leave the workload results columns out of the output dataframe.